### PR TITLE
Fix Error: Cannot resolve module 'string-hash'

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-redux": "^4.4.2",
     "react-router": "^2.1.1",
     "redux": "^3.4.0",
-    "redux-thunk": "^2.0.1"
+    "redux-thunk": "^2.0.1",
+    "string-hash": "^1.1.0"
   }
 }


### PR DESCRIPTION
string-hash dependency is used in DataList.js but not included in
package.json so an error occurred on startup...
Error: Cannot resolve module 'string-hash'
