### PR TITLE
Remove container stuff from Home component

### DIFF
--- a/src/app/components/Home/Home.js
+++ b/src/app/components/Home/Home.js
@@ -1,4 +1,3 @@
-import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
 
 const Home = () => (
@@ -16,4 +15,4 @@ const Home = () => (
 
 
 
-export default connect()(Home);
+export default Home;


### PR DESCRIPTION
This resolves #15.
Home component no longer imports nor uses connect from react-redux.
Instead just exports the Home function without any connect wrapping.
I did not find any other components with references to react-redux.
