### PR TITLE
Update readme to inform required npm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A project starter for universalmorphic React/Redux apps
 
 
-
 ## Features
 
 *   [React](https://facebook.github.io/react/): THE component-based view library.
@@ -37,3 +36,7 @@ A project starter for universalmorphic React/Redux apps
 1.  The React / Redux app is found in [src/app](./src/app)
 1.  The production Express.js server is found in [src/server](./src/server)
 1.  Component stories (for the component dev environment) is found in [.storybook/config.js](./.storybook/config.js)
+
+
+
+NOTE: Make sure you are using npm version 3 or higher.


### PR DESCRIPTION
when you use an older version of npm the whitelister will brake when
processing a node_module with no dependencies

whitelister.js line 31
packages.map(d => Object.keys(require(`${d}/package.json`).dependencies))

dependencies is null on the object require returns when using older versions
of npm. This which breaks Object.keys, which in turn breaks the build