### PR TITLE
Encourage the .js extension

### DIFF
--- a/webpack.base.babel.js
+++ b/webpack.base.babel.js
@@ -19,7 +19,7 @@ export default {
             },
 
             {
-                test : /\.jsx?$/,
+                test : /\.js$/,
                 loader  : 'babel'
             },
 


### PR DESCRIPTION
Disconfigure .jsx processing by the webpack loader to encourage use of the .js extentions... for consistency.