### PR TITLE
Qualify loader names for webpack

### DIFF
--- a/webpack.base.babel.js
+++ b/webpack.base.babel.js
@@ -20,12 +20,12 @@ export default {
 
             {
                 test : /\.jsx?$/,
-                loader  : 'babel'
+                loader  : 'babel-loader'
             },
 
             {
                 test : /\.json$/,
-                loader  : 'json'
+                loader  : 'json-loader'
             },
 
             {


### PR DESCRIPTION
webpack 2 requires the full loader name.
It will no longer automatically append "-loader" like in webpack 1.
Ya, ya, I know. Just getting ready for webpack 2.