### PR TITLE
Use `file-loader` in webpack test config to bundle images

### DIFF
--- a/.tests/webpack.js
+++ b/.tests/webpack.js
@@ -40,7 +40,7 @@ module.exports = {
 
             {
                 test: /\.(png|jpe?g|gif|svg|mp3|mpe?g)$/,
-                loader: "null-loader?name=static/assets/[name]-[hash:2].[ext]"
+                loader: "file-loader?name=static/assets/[name]-[hash:2].[ext]"
             }
 
         ]


### PR DESCRIPTION
When using null-loader we get `Error: Cannot find module...`
Fixes #87 